### PR TITLE
Charset set for message is not respected

### DIFF
--- a/Classes/Famelo/Messaging/Message.php
+++ b/Classes/Famelo/Messaging/Message.php
@@ -48,6 +48,13 @@ class Message extends \TYPO3\SwiftMailer\Message {
 	 */
 	protected $view;
 
+	public function __construct($subject = null, $body = null,
+	                            $contentType = null, $charset = null) {
+		$this->setCharset('text/html');
+
+		parent::__construct($subject, $body, $contentType, $charset);
+	}
+
 	public function setMessage($message) {
 		$parts = explode(':', $message);
 		if (count($parts) > 1) {
@@ -65,7 +72,7 @@ class Message extends \TYPO3\SwiftMailer\Message {
 			$this->setTo($redirectAllMessagesTo);
 		}
 
-		$this->setBody($this->render(), 'text/html');
+		$this->setBody($this->render(), $this->getContentType());
 		parent::send();
 	}
 


### PR DESCRIPTION
When a custom charset, like text/plain for text-only mails, is set, the
message is sent as text/html nonetheless, because the charset setting
from the SwiftMailer class is not respected.
